### PR TITLE
Fixed: sometimes it freeze when zoomed or moved.

### DIFF
--- a/src/OpenLayers.Blazor/Map.razor.cs
+++ b/src/OpenLayers.Blazor/Map.razor.cs
@@ -347,8 +347,8 @@ public partial class Map : IAsyncDisposable
     {
         if (!coordinate.Equals(Center))
         {
-            await CenterChanged.InvokeAsync(coordinate);
             Center = coordinate;
+            await CenterChanged.InvokeAsync(coordinate);
         }
     }
 


### PR DESCRIPTION
Hi,

First of all, thank you for this nice openlayers component for Blazor.

I applied the component in module for Oqtane framework (https://oqtane.org). Sometimes a freeze occurred when zooming or moving the center. This only occurred in Blazor Server mode, in WebAssembly mode there is no problem.
This little PR solves this (internal parameter Center is now set before the call to JS)