### PR TITLE
Fix mixed projection for view/coordinates, Fix coordinates transformation, Enhancement

### DIFF
--- a/src/OpenLayers.Blazor.Demo.Components/Pages/BingMapDemo.razor
+++ b/src/OpenLayers.Blazor.Demo.Components/Pages/BingMapDemo.razor
@@ -8,6 +8,7 @@
     </div>
 
     <div class="card-body">
+        <input type="text" @bind-value="_key" width="400px" placeholder="Your Bing Maps Key from https://www.bingmapsportal.com/ ">
         <select @bind="_layerselect">
             <option value="Aerial">Aerial</option>
             <option value="AerialWithLabelsOnDemand">Aerial with labels</option>
@@ -18,10 +19,14 @@
     </div>
 </div>
 
-<BingMap Style="height:800px;" Class="card" ImagerySet="@(_layerselect != null ? Enum.Parse<BingMapImagerySet>(_layerselect) : BingMapImagerySet.RoadOnDemand)" Key="Your Bing Maps Key from https://www.bingmapsportal.com/ here"></BingMap>
+@if (!string.IsNullOrEmpty(_key))
+{
+    <BingMap Style="height: 800px;" Class="card" ImagerySet="@(_layerselect != null ? Enum.Parse<BingMapImagerySet>(_layerselect) : BingMapImagerySet.RoadOnDemand)" Key="@_key"></BingMap>
+}
 
 <CodeView Source="BingMapDemo.razor" />
 
 @code {
     private string? _layerselect;
+    private string? _key;
 }

--- a/src/OpenLayers.Blazor.Demo.Components/Pages/DrawDemo.razor
+++ b/src/OpenLayers.Blazor.Demo.Components/Pages/DrawDemo.razor
@@ -1,4 +1,4 @@
-﻿@page "/drawdemo"
+﻿@page "/drawdemo/{MapType?}"
 @using System.Text.Json
 @rendermode Components.RenderMode.DefaultRenderMode
 
@@ -29,23 +29,25 @@
             <input type="range" min="1" max="30" @bind="_styleOptions.Stroke.Width" title="Border Size">
             <input type="button" class="btn btn-primary" value="Undo" @onclick="() => _map.Undo()" />
             <input type="button" class="btn btn-secondary" value="Clear" @onclick="() => _map.ShapesList.Clear()" />
-            <input type="range" min="1080000" max="1280000" value="@_y" @onchange="OnYChange"> <code>@_y</code>
         </div>
     </div>
 </div>
 
-<SwissMap @ref="_map" Style="height:800px;" Class="card" OnShapeAdded="StateHasChanged" EnableEditShapes="_enableedit" EnableNewShapes="_enabledraw" EnableShapeSnap="_snap" ShapeStyleCallback="(shape) => _styleOptions" NewShapeType="_shapeType" Freehand="_freehand">
-    <Features>
-        <Line Points="new []{new Coordinate(2604200, 1197650), new Coordinate(2624200, 1177650)}" BorderColor="red" BorderSize="2"></Line>
-        <Circle @ref="_circle" Center="_center" Radius="2000" BorderSize="3" BorderColor="blue" BackgroundColor="#55229933"></Circle>
-        <Point Coordinate="new Coordinate(2683276.620804008, 1247123.8311215444)" BackgroundColor="green" Radius="20"></Point>
-    </Features>
-</SwissMap>
-
-@*
+@if (MapType == "osm")
+{
     <OpenStreetMap @ref="_map" Style="height:800px;" Class="card" OnShapeAdded="StateHasChanged" EnableEditShapes="_enableedit" EnableNewShapes="_enabledraw" EnableShapeSnap="_snap" ShapeStyleCallback="(shape) => _styleOptions" NewShapeType="_shapeType" Freehand="_freehand">
     </OpenStreetMap>
-*@
+}
+else
+{
+    <SwissMap @ref="_map" Style="height: 800px;" Class="card" OnShapeAdded="StateHasChanged" EnableEditShapes="_enableedit" EnableNewShapes="_enabledraw" EnableShapeSnap="_snap" ShapeStyleCallback="(shape) => _styleOptions" NewShapeType="_shapeType" Freehand="_freehand">
+        <Features>
+            <Line Points="new[] { new Coordinate(2604200, 1197650), new Coordinate(2624200, 1177650) }" BorderColor="red" BorderSize="2"></Line>
+            <Circle Center="_center" Radius="2000" BorderSize="3" BorderColor="blue" BackgroundColor="#55229933"></Circle>
+            <Point Coordinate="new Coordinate(2683276.620804008, 1247123.8311215444)" BackgroundColor="green" Radius="20"></Point>
+        </Features>
+    </SwissMap>
+}
 
 @if (_map != null)
 {
@@ -73,10 +75,9 @@
 <CodeView Source="DrawDemo.razor" />
 
 @code {
-    private Map _map = null!;
+    [Parameter] public string? MapType { get; set; }
+    private Map? _map;
     private ShapeType _shapeType = ShapeType.LineString;
-    private double _y = 1197650;
-    private Circle _circle;
     private Coordinate _center = new(2604200, 1197650);
     private bool _enabledraw, _enableedit, _snap = true, _freehand;
 
@@ -98,13 +99,5 @@
         if (firstRender)
             StateHasChanged();
         return base.OnAfterRenderAsync(firstRender);
-    }
-
-    private void OnYChange(ChangeEventArgs obj)
-    {
-        _y = Double.Parse(obj.Value.ToString());
-        _center.Y = _y;
-        _circle.Center = _center;
-        _ = _circle.UpdateShape();
     }
 }

--- a/src/OpenLayers.Blazor.Demo.Components/Pages/DrawDemo.razor
+++ b/src/OpenLayers.Blazor.Demo.Components/Pages/DrawDemo.razor
@@ -35,20 +35,17 @@
 </div>
 
 <SwissMap @ref="_map" Style="height:800px;" Class="card" OnShapeAdded="StateHasChanged" EnableEditShapes="_enableedit" EnableNewShapes="_enabledraw" EnableShapeSnap="_snap" ShapeStyleCallback="(shape) => _styleOptions" NewShapeType="_shapeType" Freehand="_freehand">
-    <Popup>
-        <div id="popup" class="ol-box">
-            @if (@context != null)
-            {
-                <h3>@context.Type</h3>
-            }
-        </div>
-    </Popup>
     <Features>
         <Line Points="new []{new Coordinate(2604200, 1197650), new Coordinate(2624200, 1177650)}" BorderColor="red" BorderSize="2"></Line>
         <Circle @ref="_circle" Center="_center" Radius="2000" BorderSize="3" BorderColor="blue" BackgroundColor="#55229933"></Circle>
         <Point Coordinate="new Coordinate(2683276.620804008, 1247123.8311215444)" BackgroundColor="green" Radius="20"></Point>
     </Features>
 </SwissMap>
+
+@*
+    <OpenStreetMap @ref="_map" Style="height:800px;" Class="card" OnShapeAdded="StateHasChanged" EnableEditShapes="_enableedit" EnableNewShapes="_enabledraw" EnableShapeSnap="_snap" ShapeStyleCallback="(shape) => _styleOptions" NewShapeType="_shapeType" Freehand="_freehand">
+    </OpenStreetMap>
+*@
 
 @if (_map != null)
 {
@@ -76,7 +73,7 @@
 <CodeView Source="DrawDemo.razor" />
 
 @code {
-    private SwissMap _map = null!;
+    private Map _map = null!;
     private ShapeType _shapeType = ShapeType.LineString;
     private double _y = 1197650;
     private Circle _circle;

--- a/src/OpenLayers.Blazor.Demo.Components/Pages/Index.razor
+++ b/src/OpenLayers.Blazor.Demo.Components/Pages/Index.razor
@@ -52,8 +52,8 @@ Visible Extent: @_map?.VisibleExtent
     </Popup>
     <Features>
         <Marker Type="MarkerType.MarkerPin" Coordinate="new Coordinate(2604200, 1197650)" Popup></Marker>
-         <Marker Type="MarkerType.MarkerFlag" Coordinate="new Coordinate(2624200, 1177650)" Title="Hallo" BackgroundColor="#449933" Popup></Marker>
-         <Line Points="new[] { new Coordinate(2604200, 1197650), new Coordinate(2624200, 1177650) }" BorderColor="cyan"></Line>
+        <Marker Type="MarkerType.MarkerFlag" Coordinate="new Coordinate(2624200, 1177650)" Title="Hallo" BackgroundColor="#449933" Popup></Marker>
+        <Line Points="new[] { new Coordinate(2604200, 1197650), new Coordinate(2624200, 1177650) }" BorderColor="cyan"></Line>
      </Features>
  </SwissMap>
 

--- a/src/OpenLayers.Blazor.Demo.Components/Pages/Index.razor
+++ b/src/OpenLayers.Blazor.Demo.Components/Pages/Index.razor
@@ -30,9 +30,9 @@
         <p>
             <pre>
 Center:@_map?.Center
-Last Position: @_lastPosition?.X / @_lastPosition?.Y
+Last Position: @_lastPosition
 Altitude @(_altitude)m
-Mouse Position: @_mousePosition?.X / @_mousePosition?.Y
+Mouse Position: @_mousePosition
 Visible Extent: @_map?.VisibleExtent
 @_info
         </pre>
@@ -46,7 +46,7 @@ Visible Extent: @_map?.VisibleExtent
             @if (context is Marker marker)
             {
                 <h3>@marker.Title</h3>
-                <p>@marker.Coordinate.X / @marker.Coordinate.Y</p>
+                <p>@marker.Coordinate.X,@marker.Coordinate.Y</p>
             }
         </div>
     </Popup>

--- a/src/OpenLayers.Blazor.Demo.Components/Pages/MarkersDemo.razor
+++ b/src/OpenLayers.Blazor.Demo.Components/Pages/MarkersDemo.razor
@@ -22,7 +22,7 @@
             @if (context is Marker marker)
             {
                 <h3>@marker.Title</h3>
-                <p>@marker.Coordinate.X / @marker.Coordinate.Y</p>
+                <p>@marker.Coordinate</p>
             }
         </div>
     </Popup>

--- a/src/OpenLayers.Blazor.Demo.Components/Pages/OpenStreetMapDemo.razor
+++ b/src/OpenLayers.Blazor.Demo.Components/Pages/OpenStreetMapDemo.razor
@@ -35,11 +35,22 @@ Zoom: @_map?.Zoom
         </Layer>
         <Layer SourceType="SourceType.Graticule" />
     </Layers>
+    
+    <Features>
+        <Marker Type="MarkerType.MarkerPin" Coordinate="new Coordinate(x, y)" Title="You are Here" Popup></Marker>
+        <Circle Center="new Coordinate(x, y)" Radius="50" BackgroundColor="#2222AA66"></Circle>
+        <Point Coordinate="new Coordinate(x, y)" BorderSize="4" BorderColor="red" BackgroundColor="cyan" Radius="3"></Point>
+        <Point Coordinate="new Coordinate(x2, y2)" BorderSize="4" BorderColor="red" BackgroundColor="cyan" Radius="3"></Point>
+         <Line Points="new []{ new Coordinate(x, y), new Coordinate(x2, y2) }" BorderColor="cyan" BorderSize="20" BackgroundColor="cyan" Title="Test"></Line>
+    </Features>
+
+
 </OpenStreetMap>
 
 <CodeView Source="OpenStreetMapDemo.razor"/>
 
 @code {
+    private double x = 11, y = 49, x2 = 12, y2 = 48;
     private Coordinate _center = new(11, 49);
     //private OpenStreetMap _map;
     private Map _map;

--- a/src/OpenLayers.Blazor.Demo.Components/Pages/OpenStreetMapDemo.razor
+++ b/src/OpenLayers.Blazor.Demo.Components/Pages/OpenStreetMapDemo.razor
@@ -8,7 +8,7 @@
     <div class="card-body">
     <p>Demo with a loaded KML Layer on first map, custom WMS source on second map, synced center and a Graticule Layer on second map.</p>
     <pre>
-Center: @_center
+Center: @_map?.Center
 VisibleExtent: @_map?.VisibleExtent
 Zoom: @_map?.Zoom
     </pre>
@@ -40,7 +40,8 @@ Zoom: @_map?.Zoom
 <CodeView Source="OpenStreetMapDemo.razor"/>
 
 @code {
-    private Coordinate _center = new(7.6, 46.5);
-    private OpenStreetMap _map;
+    private Coordinate _center = new(11, 49);
+    //private OpenStreetMap _map;
+    private Map _map;
     private dynamic _kmlOptions = new { ShowPointNames = true, ExtractStyles = true };
 }

--- a/src/OpenLayers.Blazor.Demo.Components/Pages/SwissMapLayersDemo.razor
+++ b/src/OpenLayers.Blazor.Demo.Components/Pages/SwissMapLayersDemo.razor
@@ -92,7 +92,7 @@
     {
         string url = $"https://api3.geo.admin.ch/rest/services/all/MapServer/identify?geometry={coordinate.X},{coordinate.Y}&geometryFormat=geojson&geometryType=esriGeometryPoint&imageDisplay=975,1117,96&lang=en&layers=all:{_selectedLayer}&limit=10&mapExtent={_map.VisibleExtent.X1},{_map.VisibleExtent.Y1},{_map.VisibleExtent.X2},{_map.VisibleExtent.Y2}&returnGeometry=true&sr=2056&timeInstant=2021&tolerance=10";
         var json = await HttpClient.GetFromJsonAsync<JsonElement>(url);
-        var results = json.GetProperty("results");await _map.LoadGeoJson(results[0], _map.Defaults.CoordinatesProjection); // json is in EPSG:2056
+        var results = json.GetProperty("results");await _map.LoadGeoJson(results[0], _map.Options.CoordinatesProjection); // json is in EPSG:2056
     }
 
     private void OnFeatureClick(Feature feature)

--- a/src/OpenLayers.Blazor.Demo.Server/Components/Layout/NavMenu.razor
+++ b/src/OpenLayers.Blazor.Demo.Server/Components/Layout/NavMenu.razor
@@ -56,10 +56,15 @@
                 <span class="oi oi-plus" aria-hidden="true"></span> Custom Map
             </NavLink>
         </div>
-
         <div class="nav-item px-3">
             <NavLink class="nav-link" href="/drawdemo">
-                <span class="oi oi-plus" aria-hidden="true"></span> Draw Shapes
+                <span class="oi oi-plus" aria-hidden="true"></span> Draw Shapes (Swiss)
+            </NavLink>
+        </div>
+
+        <div class="nav-item px-3">
+            <NavLink class="nav-link" href="/drawdemo/osm">
+                <span class="oi oi-plus" aria-hidden="true"></span> Draw Shapes (OSM)
             </NavLink>
         </div>
         

--- a/src/OpenLayers.Blazor.Demo/Shared/NavMenu.razor
+++ b/src/OpenLayers.Blazor.Demo/Shared/NavMenu.razor
@@ -59,7 +59,13 @@
 
         <div class="nav-item px-3">
             <NavLink class="nav-link" href="/drawdemo">
-                <span class="oi oi-plus" aria-hidden="true"></span> Draw Shapes
+                <span class="oi oi-plus" aria-hidden="true"></span> Draw Shapes (Swiss)
+            </NavLink>
+        </div>
+
+        <div class="nav-item px-3">
+            <NavLink class="nav-link" href="/drawdemo/osm">
+                <span class="oi oi-plus" aria-hidden="true"></span> Draw Shapes (OSM)
             </NavLink>
         </div>
 

--- a/src/OpenLayers.Blazor/Coordinate.cs
+++ b/src/OpenLayers.Blazor/Coordinate.cs
@@ -76,7 +76,7 @@ public class Coordinate : IEquatable<Coordinate>
 
     public override string ToString()
     {
-        return $"{X}, {Y}";
+        return $"{X}/{Y}";
     }
 
     public static implicit operator Coordinate(string val)

--- a/src/OpenLayers.Blazor/Coordinate.cs
+++ b/src/OpenLayers.Blazor/Coordinate.cs
@@ -76,7 +76,7 @@ public class Coordinate : IEquatable<Coordinate>
 
     public override string ToString()
     {
-        return $"{X}/{Y}";
+        return $"{X}, {Y}";
     }
 
     public static implicit operator Coordinate(string val)

--- a/src/OpenLayers.Blazor/Extent.cs
+++ b/src/OpenLayers.Blazor/Extent.cs
@@ -48,7 +48,7 @@ public class Extent : IEquatable<Extent>
 
     public override string ToString()
     {
-        return $"{X1}/{Y1}:{X2}/{Y2}";
+        return $"{X1}, {Y1} : {X2}, {Y2}";
     }
 
     public double[] ToArray()

--- a/src/OpenLayers.Blazor/Extent.cs
+++ b/src/OpenLayers.Blazor/Extent.cs
@@ -9,6 +9,17 @@ public class Extent : IEquatable<Extent>
     {
     }
 
+    public Extent(double[] array)
+    {
+        if (array.Length != 4)
+            throw new ArgumentException("Extent must contain 4 elements.", nameof(array));
+
+        X1 = array[0];
+        Y1 = array[1];
+        X2 = array[2];
+        Y2 = array[3];
+    }
+
     public Extent(double x1, double y1, double x2, double y2)
     {
         X1 = x1;
@@ -38,5 +49,10 @@ public class Extent : IEquatable<Extent>
     public override string ToString()
     {
         return $"{X1}/{Y1}:{X2}/{Y2}";
+    }
+
+    public double[] ToArray()
+    {
+        return new[] { X1, Y1, X2, Y2 };
     }
 }

--- a/src/OpenLayers.Blazor/Extent.cs
+++ b/src/OpenLayers.Blazor/Extent.cs
@@ -48,7 +48,7 @@ public class Extent : IEquatable<Extent>
 
     public override string ToString()
     {
-        return $"{X1}, {Y1} : {X2}, {Y2}";
+        return $"{X1}/{Y1}:{X2}/{Y2}";
     }
 
     public double[] ToArray()

--- a/src/OpenLayers.Blazor/Feature.cs
+++ b/src/OpenLayers.Blazor/Feature.cs
@@ -37,7 +37,7 @@ public class Feature : ComponentBase
         set => InternalFeature.Id = value;
     }
 
-    protected Internal.Feature InternalFeature
+    internal Internal.Feature InternalFeature
     {
         get => _internalFeature;
         set
@@ -49,15 +49,33 @@ public class Feature : ComponentBase
         }
     }
 
+    /// <summary>
+    /// Gets the geometry type of the feature.
+    /// </summary>
     public GeometryTypes? GeometryType => InternalFeature.GeometryType;
 
+    /// <summary>
+    /// Gets to type of feature.
+    /// </summary>
     public string? Type => InternalFeature.Type;
 
+    /// <summary>
+    /// Gets a dictionary of all dynamic properties of a feature.
+    /// </summary>
     public Dictionary<string, dynamic> Properties => InternalFeature.Properties;
 
-    public Coordinate? Point => Coordinates?.FirstOrDefault();
+    /// <summary>
+    /// Gets the point coordinate if the shape is defined by a single coordinate e.g. point, circle.
+    /// </summary>
+    public Coordinate? Point => CoordinatesHelper.IsSingleCoordinate(InternalFeature.Coordinates) ? Coordinates?.FirstOrDefault() : null;
 
-    public IEnumerable<Coordinate>? Coordinates => CoordinatesHelper.GetCoordinates(InternalFeature.Coordinates);
+    /// <summary>
+    /// Gets an enumerator of coordinates e.g. for a line.
+    /// </summary>
+    public IEnumerable<Coordinate>? Coordinates => !CoordinatesHelper.IsMultiCoordinate(InternalFeature.Coordinates) ? CoordinatesHelper.GetCoordinates(InternalFeature.Coordinates) : null;
 
-    public IEnumerable<IEnumerable<Coordinate>> MultiCoordinates => CoordinatesHelper.GetMultiCoordinates(InternalFeature.Coordinates);
+    /// <summary>
+    /// Gets an enumerator of multi coordinates e.g. for a multi line or multi polygon shape.
+    /// </summary>
+    public IEnumerable<IEnumerable<Coordinate>>? MultiCoordinates => CoordinatesHelper.IsMultiCoordinate(InternalFeature.Coordinates) ? CoordinatesHelper.GetMultiCoordinates(InternalFeature.Coordinates) : null;
 }

--- a/src/OpenLayers.Blazor/Internal/CoordinatesHelper.cs
+++ b/src/OpenLayers.Blazor/Internal/CoordinatesHelper.cs
@@ -21,6 +21,16 @@ internal static class CoordinatesHelper
         return coordinate.Value;
     }
 
+    public static bool IsSingleCoordinate(dynamic coordinates)
+    {
+        return !IsMultiCoordinate(coordinates) && (coordinates is double[] || ((coordinates is IEnumerable<double[]> c1) && c1.Count() == 1));
+    }
+
+    public static bool IsMultiCoordinate(dynamic coordinates)
+    {
+        return coordinates is IEnumerable<IEnumerable<double[]>>;
+    }
+
     public static IEnumerable<Coordinate>? GetCoordinates(dynamic coordinates)
     {
         if (coordinates is double[] c1)

--- a/src/OpenLayers.Blazor/Map.razor.cs
+++ b/src/OpenLayers.Blazor/Map.razor.cs
@@ -141,9 +141,9 @@ public partial class Map : IAsyncDisposable
     public ObservableCollection<Layer> LayersList { get; } = new();
 
     /// <summary>
-    ///     Defaults to use for the map rendering
+    ///     Options to use for the map rendering
     /// </summary>
-    public Defaults Defaults { get; } = new();
+    public Options Options { get; } = new();
 
     /// <summary>
     ///     Class of the map element
@@ -165,8 +165,15 @@ public partial class Map : IAsyncDisposable
     [Parameter]
     public string CoordinatesProjection
     {
-        get => Defaults.CoordinatesProjection;
-        set => Defaults.CoordinatesProjection = value;
+        get => Options.CoordinatesProjection;
+        set => Options.CoordinatesProjection = value;
+    }
+
+    [Parameter]
+    public string ViewProjection
+    {
+        get => Options.ViewProjection;
+        set => Options.ViewProjection = value;
     }
 
     /// <summary>
@@ -175,8 +182,8 @@ public partial class Map : IAsyncDisposable
     [Parameter]
     public ScaleLineUnit ScaleLineUnit
     {
-        get => Defaults.ScaleLineUnit;
-        set => Defaults.ScaleLineUnit = value;
+        get => Options.ScaleLineUnit;
+        set => Options.ScaleLineUnit = value;
     }
 
     /// <summary>
@@ -185,8 +192,8 @@ public partial class Map : IAsyncDisposable
     [Parameter]
     public bool AutoPopup
     {
-        get => Defaults.AutoPopup;
-        set => Defaults.AutoPopup = value;
+        get => Options.AutoPopup;
+        set => Options.AutoPopup = value;
     }
 
     /// <summary>
@@ -304,7 +311,7 @@ public partial class Map : IAsyncDisposable
             Instance ??= DotNetObjectReference.Create(this);
 
             if (_module != null)
-                await _module.InvokeVoidAsync("MapOLInit", _mapId, _popupId, Defaults, Center.Value, Zoom,
+                await _module.InvokeVoidAsync("MapOLInit", _mapId, _popupId, Options, Center.Value, Zoom,
                     MarkersList.Select(p => p.InternalFeature).ToArray(),
                     ShapesList.Select(p => p.InternalFeature).ToArray(),
                     LayersList.Select(p => p.InternalLayer).ToArray(),

--- a/src/OpenLayers.Blazor/Map.razor.cs
+++ b/src/OpenLayers.Blazor/Map.razor.cs
@@ -16,14 +16,17 @@ public partial class Map : IAsyncDisposable
     private IJSObjectReference? _module;
     private Feature? _popupContext;
     private string _popupId;
+    private static int _counter = 0;
+
 
     /// <summary>
     ///     Default Constructor
     /// </summary>
     public Map()
     {
-        _mapId = Guid.NewGuid().ToString();
-        _popupId = Guid.NewGuid().ToString();
+        _counter++;
+        _mapId = "map_" + _counter;
+        _popupId = "map_popup_" + _counter;
 
         EnableShapeSnap = true;
     }

--- a/src/OpenLayers.Blazor/Options.cs
+++ b/src/OpenLayers.Blazor/Options.cs
@@ -4,22 +4,49 @@ namespace OpenLayers.Blazor;
 
 public class Options
 {
+    /// <summary>
+    /// Gets or sets whenever the popup shall be shown when clicking on a feature.
+    /// </summary>
     public bool AutoPopup { get; set; }
 
+    /// <summary>
+    /// Default label for markers.
+    /// </summary>
     public string? Label { get; set; }
 
+    /// <summary>
+    /// Default color for markers.
+    /// </summary>
     public string Color { get; set; } = "#FFFFFF";
 
+    /// <summary>
+    /// Default background color for markers.
+    /// </summary>
     public string BackgroundColor { get; set; } = "#0000FF";
 
+    /// <summary>
+    /// Default border color for markers.
+    /// </summary>
     public string BorderColor { get; set; } = "#FFFFFF";
 
+    /// <summary>
+    /// Projection code how the coordinates are represented. Default is EPSG:4326.
+    /// </summary>
     public string CoordinatesProjection { get; set; } = "EPSG:4326";
 
+    /// <summary>
+    /// Code of the view of the map shall be projected. If not given, the default view of the first layer is used.
+    /// </summary>
     public string? ViewProjection { get; set; }
 
+    /// <summary>
+    /// Scale unit of the map. Default is <see cref="ScaleLineUnit.Metric"/>.
+    /// </summary>
     [JsonConverter(typeof(JsonStringEnumConverter))]
     public ScaleLineUnit ScaleLineUnit { get; set; } = ScaleLineUnit.Metric;
 
+    /// <summary>
+    /// Sets or gets the limit whenever the list of coordinates of a feature shall be included in events to improve response times.  
+    /// </summary>
     public int SerializationCoordinatesLimit { get; set; } = 512;
 }

--- a/src/OpenLayers.Blazor/Options.cs
+++ b/src/OpenLayers.Blazor/Options.cs
@@ -2,7 +2,7 @@
 
 namespace OpenLayers.Blazor;
 
-public class Defaults
+public class Options
 {
     public bool AutoPopup { get; set; }
 
@@ -15,6 +15,8 @@ public class Defaults
     public string BorderColor { get; set; } = "#FFFFFF";
 
     public string CoordinatesProjection { get; set; } = "EPSG:4326";
+
+    public string? ViewProjection { get; set; }
 
     [JsonConverter(typeof(JsonStringEnumConverter))]
     public ScaleLineUnit ScaleLineUnit { get; set; } = ScaleLineUnit.Metric;

--- a/src/OpenLayers.Blazor/SwissMap.cs
+++ b/src/OpenLayers.Blazor/SwissMap.cs
@@ -9,7 +9,8 @@ public class SwissMap : Map
         LayerId = "ch.swisstopo.pixelkarte-farbe";
         SetBaseLayer(LayerId);
         Center = new Coordinate { X = 2660013.54, Y = 1185171.98 }; // Swiss Center
-        Defaults.CoordinatesProjection = "EPSG:2056"; // VT95
+        Options.CoordinatesProjection = "EPSG:2056";
+        Options.ViewProjection = "EPSG:2056"; 
         Zoom = 2.4;
     }
 

--- a/src/OpenLayers.Blazor/wwwroot/openlayers_interop.js
+++ b/src/OpenLayers.Blazor/wwwroot/openlayers_interop.js
@@ -554,7 +554,7 @@ MapOL.prototype.onMapClick = function (evt, popup, element) {
                 showPopup = shape.properties.popup;
             } 
             if (showPopup == undefined) {
-                showPopup = that.Defaults.autoPopup;
+                showPopup = that.Options.autoPopup;
             }
 
             if (showPopup) {
@@ -730,7 +730,7 @@ MapOL.prototype.mapFeatureToShape = function (feature) {
                 var l = g.length;
                 if (Array.isArray(g[0])) g.forEach((g2) => l = l + g2.length);
                 if (l < this.Options.serializationCoordinatesLimit)
-                    coordinates = ol.proj.transform(geometry.getCoordinates(),
+                    coordinates = MapOL.transformCoordinates(geometry.getCoordinates(),
                         viewProjection,
                         this.Options.coordinatesProjection);
                 break;
@@ -787,8 +787,7 @@ MapOL.prototype.mapShapeToFeature = function (shape) {
     var geometry;
     const viewProjection = this.Map.getView().getProjection();
     if (shape.coordinates) {
-        var coordinates = ol.proj.transform(shape.coordinates, this.Options.coordinatesProjection, viewProjection);
-
+        var coordinates = MapOL.transformCoordinates(shape.coordinates, this.Options.coordinatesProjection, viewProjection);
         switch (shape.geometryType) {
             case "Point":
                 geometry = new ol.geom.Point(coordinates);
@@ -1156,7 +1155,6 @@ MapOL.prototype.mapStyleOptionsToStyle = function(style, feature) {
     return styleObject;
 };
 
-
 MapOL.transformNullToUndefined = function transformNullToUndefined(obj) {
     for (const key in obj) {
         if (obj.hasOwnProperty(key) && obj[key] === null) {
@@ -1167,6 +1165,29 @@ MapOL.transformNullToUndefined = function transformNullToUndefined(obj) {
     }
     return obj;
 };
+
+MapOL.transformCoordinates = function(coordinates, source, destination) {
+    var newCoordinates;
+    if (source === destination)
+        return coordinates;
+    if (Array.isArray(coordinates) && Array.isArray(coordinates[0])) {
+        newCoordinates = Array(coordinates.length);
+        for (var i = 0; i < coordinates.length; i++) {
+
+            if (Array.isArray(coordinates[i][0])) {
+                newCoordinates[i] = Array(coordinates[i].length);
+                for (var i2 = 0; i2 < coordinates[i].length; i2++) {
+                    newCoordinates[i][i2] = ol.proj.transform(coordinates[i][i2], source, destination);
+                }
+            } else {
+                newCoordinates[i] = ol.proj.transform(coordinates[i], source, destination);
+            }
+        }
+    } else {
+        newCoordinates = ol.proj.transform(coordinates, source, destination);
+    }
+    return newCoordinates;
+}
 
 /*
  * Swiss projection transform functions downloaded from

--- a/src/OpenLayers.Blazor/wwwroot/openlayers_interop.js
+++ b/src/OpenLayers.Blazor/wwwroot/openlayers_interop.js
@@ -84,6 +84,10 @@ export function MapOLAddShape(mapId, shape) {
     _MapOL[mapId].addShape(shape);
 }
 
+export function MapOLGetCoordinates(mapId, shapeId) {
+    return _MapOL[mapId].getCoordinates(shapeId);
+}
+
 
 // --- MapOL ----------------------------------------------------------------------------//
 
@@ -955,6 +959,17 @@ MapOL.prototype.addShape = function (shape) {
     var feature = this.mapShapeToFeature(shape);
     source.addFeature(feature);
 };
+
+MapOL.prototype.getCoordinates = function(featureId) {
+    var feature = this.Geometries.getSource().getFeatureById(featureId);
+    if (feature) {
+        var coord = feature.getGeometry().getCoordinates();
+        if (!coord)
+            coord = feature.getGeometry().getCenter();
+        return coord;
+    }
+    return null;
+}
 
 //--- Styles -----------------------------------------------------------------//
 

--- a/src/OpenLayers.Blazor/wwwroot/openlayers_interop.js
+++ b/src/OpenLayers.Blazor/wwwroot/openlayers_interop.js
@@ -1,7 +1,7 @@
 ﻿var _MapOL = new Array();
 
-export function MapOLInit(mapId, popupId, defaults, center, zoom, markers, shapes, layers, instance) {
-    _MapOL[mapId] = new MapOL(mapId, popupId, defaults, center, zoom, markers, shapes, layers, instance);
+export function MapOLInit(mapId, popupId, options, center, zoom, markers, shapes, layers, instance) {
+    _MapOL[mapId] = new MapOL(mapId, popupId, options, center, zoom, markers, shapes, layers, instance);
 }
 
 export function MapOLDispose(mapId) {
@@ -16,8 +16,8 @@ export function MapOLZoom(mapId, zoom) {
     _MapOL[mapId].setZoom(zoom);
 }
 
-export function MapOLSetDefaults(mapId, defaults) {
-    _MapOL[mapId].setDefaults(defaults);
+export function MapOLSetOptions(mapId, options) {
+    _MapOL[mapId].setOptions(options);
 }
 
 export function MapOLLoadGeoJson(mapId, json, dataProjection, raiseEvents) {
@@ -87,15 +87,15 @@ export function MapOLAddShape(mapId, shape) {
 
 // --- MapOL ----------------------------------------------------------------------------//
 
-function MapOL(mapId, popupId, defaults, center, zoom, markers, shapes, layers, instance) {
+function MapOL(mapId, popupId, options, center, zoom, markers, shapes, layers, instance) {
     this.Instance = instance;
-    this.Defaults = defaults;
+    this.Options = options;
 
     //LV03
     const projectionLV03 = new ol.proj.Projection({
         code: "EPSG:21781",
         extent: [485869.5728, 76443.1884, 837076.5648, 299941.7864],
-        units: "m",
+        units: "m"
     });
     ol.proj.addProjection(projectionLV03);
 
@@ -103,7 +103,7 @@ function MapOL(mapId, popupId, defaults, center, zoom, markers, shapes, layers, 
     const projectionLV95 = new ol.proj.Projection({
         code: "EPSG:2056",
         extent: [2485071.58, 1074261.72, 2837119.8, 1299941.79],
-        units: "m",
+        units: "m"
     });
     ol.proj.addProjection(projectionLV95);
 
@@ -113,13 +113,13 @@ function MapOL(mapId, popupId, defaults, center, zoom, markers, shapes, layers, 
         function (coordinate) {
             return [
                 MapOL.WGStoLV03y(coordinate[1], coordinate[0]),
-                MapOL.WGStoLV03x(coordinate[1], coordinate[0]),
+                MapOL.WGStoLV03x(coordinate[1], coordinate[0])
             ];
         },
         function (coordinate) {
             return [
                 MapOL.CHtoLV03lng(coordinate[0], coordinate[1]),
-                MapOL.CHtoLV03lat(coordinate[0], coordinate[1]),
+                MapOL.CHtoLV03lat(coordinate[0], coordinate[1])
             ];
         }
     );
@@ -130,39 +130,51 @@ function MapOL(mapId, popupId, defaults, center, zoom, markers, shapes, layers, 
         function (coordinate) {
             return [
                 MapOL.WGStoLV95y(coordinate[1], coordinate[0]),
-                MapOL.WGStoLV95x(coordinate[1], coordinate[0]),
+                MapOL.WGStoLV95x(coordinate[1], coordinate[0])
             ];
         },
         function (coordinate) {
             return [
                 MapOL.LV95toWGSlng(coordinate[0], coordinate[1]),
-                MapOL.LV95toWGSlat(coordinate[0], coordinate[1]),
+                MapOL.LV95toWGSlat(coordinate[0], coordinate[1])
             ];
         }
     );
 
-    const ollayers = MapOL.prepareLayers(layers);
+    if (!this.Options.coordinatesProjection)
+        this.Options.coordinatesProjection = "EPSG:4326"; // default coordinates
 
-    let viewProjection = undefined;
+    const ollayers = this.prepareLayers(layers);
+
+    let viewProjection = (ollayers.length > 0) ? ollayers[0].getSource().getProjection() : undefined;
     let viewExtent = (ollayers.length > 0) ? ollayers[0].getExtent() : undefined;
     let viewCenter = (center && center) ? center : undefined;
-    if (this.Defaults.coordinatesProjection == "EPSG:2056") {
-        viewProjection = projectionLV95;
-    } else if (this.Defaults.coordinatesProjection == "EPSG:21781") {
-        viewProjection = projectionLV03;
-    } else if (this.Defaults.coordinatesProjection == "EPSG:4326") {
-        if (viewCenter)
-            viewCenter = ol.proj.transform(viewCenter, "EPSG:4326", "EPSG:3857");
+
+    if (this.Options.viewProjection) {
+        viewProjection = this.Options.viewProjection;
+    } else {
+        if (!viewProjection) {
+            if (this.Options.coordinatesProjection == "EPSG:2056") {
+                viewProjection = projectionLV95;
+            } else if (this.Options.coordinatesProjection == "EPSG:21781") {
+                viewProjection = projectionLV03;
+            } else {
+                viewProjection = "EPSG:3857"; // default view
+            }
+        }
     }
+
+    if (viewCenter)
+        viewCenter = ol.proj.transform(viewCenter, this.Options.coordinatesProjection, viewProjection);
 
     this.Map = new ol.Map({
         layers: ollayers,
         target: mapId,
-        controls: defaults.scaleLineUnit != "none"
+        controls: this.Options.scaleLineUnit != "none"
             ? ol.control.defaults.defaults().extend([
                 new ol.control.ScaleLine({
-                    units: defaults.scaleLineUnit.toLowerCase(),
-                }),
+                    units: this.Options.scaleLineUnit.toLowerCase()
+                })
             ])
             : null,
         view: new ol.View({
@@ -200,7 +212,7 @@ function MapOL(mapId, popupId, defaults, center, zoom, markers, shapes, layers, 
         element: popupElement,
         positioning: "bottom-center",
         stopEvent: false,
-        offset: [0, -50],
+        offset: [0, -50]
     });
 
     this.Map.addOverlay(popup);
@@ -216,14 +228,20 @@ function MapOL(mapId, popupId, defaults, center, zoom, markers, shapes, layers, 
     this.onMapCenterChanged();
 }
 
-MapOL.prepareLayers = function (layers) {
+MapOL.prototype.prepareLayers = function (layers) {
     const ollayers = new Array();
+    let that = this;
 
     layers.forEach((l, i, arr) => {
 
         let source;
         let sourceType = l.source.sourceType;
         l = MapOL.transformNullToUndefined(l);
+
+        if (l.extent && this.Options.coordinatesProjection) {
+            let projection = l.source.projection ?? "EPSG:3857";
+            l.extent = ol.proj.transformExtent(l.extent, that.Options.coordinatesProjection, projection);
+        }
 
         switch (sourceType) {
             case "TileImage":
@@ -329,7 +347,7 @@ MapOL.prepareLayers = function (layers) {
                 if (source == undefined) {
                     source = {
                         showLabels: true,
-                        wrapX: false,
+                        wrapX: false
                     };
                 }
                 break;
@@ -348,7 +366,7 @@ MapOL.prepareLayers = function (layers) {
 };
 
 MapOL.prototype.setLayers = function (layers) {
-    this.Map.setLayers(MapOL.prepareLayers(layers));
+    this.Map.setLayers(this.prepareLayers(layers));
 };
 
 MapOL.prototype.removeLayer = function (layer) {
@@ -364,12 +382,12 @@ MapOL.prototype.removeLayer = function (layer) {
 };
 
 MapOL.prototype.addLayer = function (layer) {
-    const ollayers = MapOL.prepareLayers([layer]);
+    const ollayers = this.prepareLayers([layer]);
     this.Map.addLayer(ollayers[0]);
 };
 
 MapOL.prototype.updateLayer = function (layer) {
-    const ollayers = MapOL.prepareLayers([layer]);
+    const ollayers = this.prepareLayers([layer]);
     const olayer = this.findLayer(ollayers[0]);
     if (olayer != undefined) {
         olayer.setVisible(layer.visibility);
@@ -430,7 +448,7 @@ MapOL.prototype.loadGeoJson = function (json, dataProjection, raiseEvents) {
     if (!json) return;
 
     const features = (new ol.format.GeoJSON()).readFeatures(json,
-        { featureProjection: this.Defaults.coordinatesProjection, dataProjection: dataProjection });
+        { featureProjection: this.Options.coordinatesProjection, dataProjection: dataProjection });
 
     const geoSource = new ol.source.Vector({
         features: features
@@ -477,12 +495,12 @@ MapOL.prototype.setZoomToExtent = function (extent) {
 
 MapOL.prototype.setCenter = function (point) {
     this.Map.getView().setCenter(ol.proj.transform(point,
-        this.Defaults.coordinatesProjection,
-        this.Map.getView().getProjection().getCode()));
+        this.Options.coordinatesProjection,
+        this.Map.getView().getProjection()));
 };
 
-MapOL.prototype.setDefaults = function (defaults) {
-    this.Defaults = defaults;
+MapOL.prototype.setOptions = function (options) {
+    this.Options = options;
 };
 
 MapOL.prototype.getReducedFeature = function (feature) {
@@ -548,7 +566,7 @@ MapOL.prototype.onMapClick = function (evt, popup, element) {
 
     if (invokeMethod) {
         invokeMethod = false;
-        const coordinate = ol.proj.transform(evt.coordinate, "EPSG:3857", this.Defaults.coordinatesProjection);
+        const coordinate = ol.proj.transform(evt.coordinate, this.Map.getView().getProjection(), this.Options.coordinatesProjection);
         const point = coordinate[0] + "/" + coordinate[1];
         this.Instance.invokeMethodAsync("OnInternalClick", point);
     }
@@ -559,8 +577,8 @@ MapOL.prototype.onMapPointerMove = function (evt, element) {
         return;
     }
     const coordinate = ol.proj.transform(evt.coordinate,
-        this.Map.getView().getProjection().getCode(),
-        this.Defaults.coordinatesProjection);
+        this.Map.getView().getProjection(),
+        this.Options.coordinatesProjection);
     const point = coordinate[0] + "/" + coordinate[1];
     this.Instance.invokeMethodAsync("OnInternalPointerMove", point);
 };
@@ -573,8 +591,8 @@ MapOL.prototype.onMapCenterChanged = function () {
     const center = this.Map.getView().getCenter();
     if (!center) return;
     const coordinate = ol.proj.transform(center,
-        this.Map.getView().getProjection().getCode(),
-        this.Defaults.coordinatesProjection);
+        this.Map.getView().getProjection(),
+        this.Options.coordinatesProjection);
     const point = coordinate[0] + "/" + coordinate[1];
     this.Instance.invokeMethodAsync("OnInternalCenterChanged", point);
     this.onVisibleExtentChanged();
@@ -584,11 +602,11 @@ MapOL.prototype.onVisibleExtentChanged = function () {
     if (this.disableVisibleExtentChanged) return;
     const extentArray = this.Map.getView().calculateExtent(this.Map.getSize());
     const coordinate1 = ol.proj.transform([extentArray[0], extentArray[1]],
-        this.Map.getView().getProjection().getCode(),
-        this.Defaults.coordinatesProjection);
+        this.Map.getView().getProjection(),
+        this.Options.coordinatesProjection);
     const coordinate2 = ol.proj.transform([extentArray[2], extentArray[3]],
-        this.Map.getView().getProjection().getCode(),
-        this.Defaults.coordinatesProjection);
+        this.Map.getView().getProjection(),
+        this.Options.coordinatesProjection);
     const extent = { X1: coordinate1[0], Y1: coordinate1[1], X2: coordinate2[0], Y2: coordinate2[1] };
     this.Instance.invokeMethodAsync("OnInternalVisibleExtentChanged", extent);
 };
@@ -699,22 +717,22 @@ MapOL.prototype.mapFeatureToShape = function (feature) {
     if (feature == null) return null;
 
     var geometry = feature.getGeometry();
-    var viewProjection = this.Map.getView().getProjection().getCode();
+    var viewProjection = this.Map.getView().getProjection();
     var coordinates = null;
 
     if (geometry != null && !Array.isArray(geometry)) {
         switch (geometry.getType()) {
             case "Circle":
-                coordinates = ol.proj.transform(geometry.getCenter(), viewProjection, this.Defaults.coordinatesProjection);
+                coordinates = ol.proj.transform(geometry.getCenter(), viewProjection, this.Options.coordinatesProjection);
                 break;
             default:
                 var g = geometry.getCoordinates();
                 var l = g.length;
                 if (Array.isArray(g[0])) g.forEach((g2) => l = l + g2.length);
-                if (l < this.Defaults.serializationCoordinatesLimit)
+                if (l < this.Options.serializationCoordinatesLimit)
                     coordinates = ol.proj.transform(geometry.getCoordinates(),
                         viewProjection,
-                        this.Defaults.coordinatesProjection);
+                        this.Options.coordinatesProjection);
                 break;
         }
     }
@@ -767,9 +785,9 @@ MapOL.prototype.mapFeatureToShape = function (feature) {
 MapOL.prototype.mapShapeToFeature = function (shape) {
 
     var geometry;
-    const viewProjection = this.Map.getView().getProjection().getCode();
+    const viewProjection = this.Map.getView().getProjection();
     if (shape.coordinates) {
-        var coordinates = ol.proj.transform(shape.coordinates, this.Defaults.coordinatesProjection, viewProjection);
+        var coordinates = ol.proj.transform(shape.coordinates, this.Options.coordinatesProjection, viewProjection);
 
         switch (shape.geometryType) {
             case "Point":
@@ -841,9 +859,9 @@ MapOL.prototype.mapShapeToFeature = function (shape) {
 MapOL.prototype.getDefaultStyle = function (shape) {
 
     if (shape.geometryType == "Point") {
-        const viewProjection = this.Map.getView().getProjection().getCode();
+        const viewProjection = this.Map.getView().getProjection();
         const coordinates = ol.proj.transform(shape.coordinates ?? this.Map.getView().getCenter(),
-            this.Defaults.coordinatesProjection,
+            this.Options.coordinatesProjection,
             viewProjection);
         let radius = 5;
         if (shape.radius != null) {
@@ -1043,7 +1061,7 @@ MapOL.prototype.awesomeStyle = function (marker) {
                 offset: [0, 0],
                 opacity: 1,
                 scale: 0.5,
-                color: marker.color ?? this.Defaults.color,
+                color: marker.color ?? this.Options.color,
                 anchorXUnits: "pixels",
                 anchorYUnits: "pixels",
                 src: "./_content/OpenLayers.Blazor/img/pin-back.png"
@@ -1055,18 +1073,18 @@ MapOL.prototype.awesomeStyle = function (marker) {
                 scale: 2,
                 font: '900 18px "Font Awesome 6 Free"',
                 textBaseline: "bottom",
-                fill: new ol.style.Fill({ color: marker.backgroundColor ?? this.Defaults.backgroundColor }),
-                stroke: new ol.style.Stroke({ color: marker.borderColor ?? this.Defaults.borderColor, width: 3 })
+                fill: new ol.style.Fill({ color: marker.backgroundColor ?? this.Options.backgroundColor }),
+                stroke: new ol.style.Stroke({ color: marker.borderColor ?? this.Options.borderColor, width: 3 })
             })
         }),
         new ol.style.Style({
             text: new ol.style.Text({
-                text: marker.properties?.label ?? this.Defaults.label,
+                text: marker.properties?.label ?? this.Options.label,
                 offsetY: -22,
                 opacity: 1,
                 scale: 1,
                 font: '900 18px "Font Awesome 6 Free"',
-                fill: new ol.style.Fill({ color: marker.color ?? this.Defaults.color })
+                fill: new ol.style.Fill({ color: marker.color ?? this.Options.color })
             })
         })
     ];


### PR DESCRIPTION
- Fix coordinates transformation in interop
- Rename Defaults property to Options
- Adjust string representation for Coordinates and Extent
- Add method Map.ReadCoordinates(feature) to get explicitly the latest coordinates of a feature.
- Fixes #34 
- Fixes #35 