### PR TITLE
Update openlayers_interop.js to fix checking for ScaleLineUnit None

### DIFF
--- a/src/OpenLayers.Blazor/wwwroot/openlayers_interop.js
+++ b/src/OpenLayers.Blazor/wwwroot/openlayers_interop.js
@@ -544,7 +544,7 @@ MapOL.prototype.addControls = function() {
     if (this.Options.fullScreenControl) this.Map.addControl(new ol.control.FullScreen());
     if (this.Options.zoomSliderControl) this.Map.addControl(new ol.control.ZoomSlider());
     if (this.Options.rotateControl) this.Map.addControl(new ol.control.Rotate());
-    if (this.Options.scaleLineUnit != "none") {
+    if (this.Options.scaleLineUnit != "None") {
         this.Map.addControl(new ol.control.ScaleLine({
             units: this.Options.scaleLineUnit.toLowerCase()
         }));


### PR DESCRIPTION
If "None" is passed as a unit, OL fails with invalid unit error.  This fix correctly checks if user disables the scale line.