### PR TITLE
Fix Style color object for IconStyleOptions.

### DIFF
--- a/src/OpenLayers.Blazor/StyleOptions.cs
+++ b/src/OpenLayers.Blazor/StyleOptions.cs
@@ -172,7 +172,7 @@ public class StyleOptions
         [JsonConverter(typeof(JsonStringEnumKebabLowerConverter))]
         public IconAnchorUnits AnchorYUnits { get; set; }
 
-        public string Color { get; set; }
+        public int[] Color { get; set; }
 
         public string CrossOrigin { get; set; }
         public double? Width { get; set; }


### PR DESCRIPTION
- OL js represents RGBA as int array and setting Color breaks JSInterop when string.  This is due to an object seriallizatoin error if color is not null for methods such as new feature added, or feature clicked.
- Future extensions could include allowing Color application along with other style options in the SetCustomImageStyle method.
- Setting the style color allows image markers to be tinted.

Without public access to Color, the style can now be set for image markers:

newMarker.Styles[0].Icon.Color = new int[] { 125, 0, 0, 255 };  // For example

The effect is that the same image (icon) can be used to represent different things but styled with different color tints.

Possible alternative could be to create a custom Json Serializer that maps string RGB / Hex values in C# with int[] arrays being serialized on js side.  Passing a string to color does almost work, but any JSInterop calls break as OL converts the strings to int arrays in the js object (causing serialization back to C# object to fail).