### PR TITLE
Fix for broken shape list remove method

### DIFF
--- a/src/OpenLayers.Blazor/wwwroot/openlayers_interop.js
+++ b/src/OpenLayers.Blazor/wwwroot/openlayers_interop.js
@@ -1,4 +1,4 @@
-﻿var _MapOL = new Array();
+var _MapOL = new Array();
 
 export function MapOLInit(mapId, popupId, options, center, zoom, rotation, interactions, layers, instance, configureJsMethod) {
     _MapOL[mapId] = new MapOL(mapId, popupId, options, center, zoom, rotation, interactions, layers, instance, configureJsMethod);
@@ -84,7 +84,7 @@ export function MapOLSetShapes(mapId, layerId, shapes) {
 }
 
 export function MapOLRemoveShape(mapId, layerId, shape) {
-    _MapOL[mapId]?.removeShape(layerId, shape);
+    _MapOL[mapId].removeShapes(layerId, shape);
 }
 
 export function MapOLAddShape(mapId, layerId, shapes) {


### PR DESCRIPTION
Fixes #110

Rename invalid js method name from removeShape to removeShapes

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/lolochristen/OpenLayers.Blazor/pull/111?shareId=57c6ad84-d9cc-4c95-a54c-0d82e1c31c5f).