### PR TITLE
Fix zindex for updatelayer method

### DIFF
--- a/src/OpenLayers.Blazor/wwwroot/openlayers_interop.js
+++ b/src/OpenLayers.Blazor/wwwroot/openlayers_interop.js
@@ -500,7 +500,7 @@ MapOL.prototype.updateLayer = function(layer) {
     if (olayer != undefined) {
         olayer.setVisible(layer.visibility);
         olayer.setOpacity(layer.opacity);
-        olayer.setZIndex(layer.zindex);
+        olayer.setZIndex(layer.zIndex);
         olayer.setExtent(layer.extent);
     }
 };


### PR DESCRIPTION
Hello,

I found a bug in `updatelayer` in the interop javascript: updating `ZIndex` of a layer from C# didn't work.

In javascript the case of `zIndex` wasn't right in the `updatelayer` method